### PR TITLE
[FEATURE] Use `stdWrap` for given defined settings

### DIFF
--- a/Classes/Controller/DefaultController.php
+++ b/Classes/Controller/DefaultController.php
@@ -30,6 +30,8 @@ class DefaultController extends ActionController
             throw new \Exception('EXT:pluploadfe is not installed!');
         }
 
+        $this->buildSettings();
+
         if (empty($this->settings['mailTo']['email'])) {
             throw new \Exception('No mail to address given!');
         }
@@ -142,5 +144,31 @@ class DefaultController extends ActionController
     protected function getErrorFlashMessage(): bool|string
     {
         return false;
+    }
+
+    protected function buildSettings(): void
+    {
+        // Use stdWrap for given defined settings
+        if (isset($this->settings['useStdWrap']) && !empty($this->settings['useStdWrap'])) {
+            $stdWrapProperties = GeneralUtility::trimExplode(',', $this->settings['useStdWrap'], true);
+
+            foreach ($stdWrapProperties as $key) {
+                $segments = GeneralUtility::trimExplode('.', $key, true);
+                if ($segments[1] ?? '') {
+                    if (is_array($this->settings[$segments[0]][$segments[1]] ?? null)) {
+                        $cObject = $this->request->getAttribute('currentContentObject');
+                        $this->settings[$segments[0]][$segments[1]] = $cObject->stdWrap(
+                            $this->settings[$segments[0]][$segments[1]]['_typoScriptNodeValue'] ?? '',
+                            $this->settings[$segments[0]][$segments[1]]
+                        );
+                    }
+                } elseif (is_array($this->settings[$segments[0]] ?? null)) {
+                    $this->settings[$segments[0]] = $this->request->getAttribute('currentContentObject')->stdWrap(
+                        $this->settings[$segments[0]]['_typoScriptNodeValue'] ?? '',
+                        $this->settings[$segments[0]]
+                    );
+                }
+            }
+        }
     }
 }

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -14,6 +14,16 @@ plugin.tx_mailfiles_pi1 {
 	}
 
 	settings {
+		# By using "useStdWrap" it is possible to call the full range of stdWrap on any setting:
+		#
+		# useStdWrap := addToList(mailTo.email,mailTo.name)
+		# mailTo {
+		# 	email = TEXT
+		# 	email.data = TSFE:fe_user|user|email
+		# 	name = TEXT
+		# 	name.data = TSFE:fe_user|user|username
+		# }
+
         # When using the core fluid mail functionality, you will need to configure the MAIL.templateRootPaths
         # configuration in order to override the template and partial paths. See TYPO3 docs:
         # https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Mail/Index.html#send-email-with-fluidemail


### PR DESCRIPTION
With the new plugin setting `useStdWrap`, it is now possible to define settings in a comma-separated list whose values are to be determined with the help of `stdWrap`.

Example:

```
plugin.tx_mailfiles_pi1 {
  settings {
    useStdWrap := addToList(mailTo.email,mailTo.name)
    mailTo {
      email = TEXT
      email.data = TSFE:fe_user|user|email
      name = TEXT
      name.data = TSFE:fe_user|user|username
    }
  }
}
```