### PR TITLE
[BUGFIX] Fix From/To name in mail

### DIFF
--- a/Classes/Service/BaseEmailService.php
+++ b/Classes/Service/BaseEmailService.php
@@ -64,8 +64,8 @@ abstract class BaseEmailService implements SingletonInterface
 
         $message = $this->createMailMessage()
             ->subject($subject)
-            ->to(new Address(key($mailTo), current($mailTo) || ''))
-            ->from(new Address(key($mailFrom), current($mailFrom) || ''));
+            ->to(new Address(key($mailTo), current($mailTo) ?? ''))
+            ->from(new Address(key($mailFrom), current($mailFrom) ?? ''));
 
 		// @extensionScannerIgnoreLine
         return $this->send($message, $variables, $templateFile);


### PR DESCRIPTION
Fix the fallback notation in the case that no value has been configrued for the From/To name. Previously, the value “1” was incorrectly used in mails regardless of which value was configured for the name.