### PR TITLE
[BUGFIX] Fix TypoScript constant compatibility with TYPO3 v12

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -53,3 +53,19 @@ plugin.tx_mailfiles_pi1 {
 		}
 	}
 }
+
+[compatVersion("12") && "{$plugin.tx_mailfiles_pi1.view.templateRootPath}" != ""]
+	plugin.tx_mailfiles_pi1.view.templateRootPaths.1 = {$plugin.tx_mailfiles_pi1.view.templateRootPath}
+[END]
+
+[compatVersion("12") && "{$plugin.tx_mailfiles_pi1.view.partialRootPath}" != ""]
+	plugin.tx_mailfiles_pi1.view.partialRootPaths.1 = {$plugin.tx_mailfiles_pi1.view.partialRootPath}
+[END]
+
+[compatVersion("12") && "{$plugin.tx_mailfiles_pi1.view.layoutRootPath}" != ""]
+	plugin.tx_mailfiles_pi1.view.layoutRootPaths.1 = {$plugin.tx_mailfiles_pi1.view.layoutRootPath}
+[END]
+
+[compatVersion("12") && "{$plugin.tx_mailfiles_pi1.view.pluploadfeTemplateFile}" != ""]
+	plugin.tx_mailfiles_pi1.settings.pluploadfe.templateFile = {$plugin.tx_mailfiles_pi1.view.pluploadfeTemplateFile}
+[END]


### PR DESCRIPTION
For TYPO3 v12 the null coalescing operator (??) in TypoScript constants is not available. This change introduces conditions using `compatVersion("12")` to only apply static constant values from `plugin.tx_mailfiles_pi1.*` if they are set and non-empty.

This ensures that templateRootPaths, partialRootPaths, layoutRootPaths and pluploadfeTemplateFile can be configured via static TypoScript includes in v12, while the `??` syntax remains in use for v13+.

Resolves: #9