### PR TITLE
[TASK] Adjust TSconfig registration for TYPO3 v13 compatibility

### DIFF
--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:mailfiles/Configuration/TSconfig/page.tsconfig'

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,11 +8,6 @@ defined('TYPO3') || die('Access denied.');
 
 call_user_func(
     static function () {
-        // Add page TS config
-        ExtensionManagementUtility::addPageTSConfig(
-            '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:mailfiles/Configuration/TSconfig/page.tsconfig">'
-        );
-
         // Configure plugin
         ExtensionUtility::configurePlugin(
             'Mailfiles',


### PR DESCRIPTION
## Description

The registration of PageTSconfig was updated to follow TYPO3 v13 best practices:

* Replaced `addPageTSConfig()` with `@import` syntax.

## References

* Deprecation of `ExtensionManagementUtility::addPageTSConfig()` (see [#101799](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Deprecation-101799-ExtensionManagementUtilityaddPageTSConfig.html))